### PR TITLE
using price scale api from series api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 /local.properties
 /.idea/*
+.idea
 .DS_Store
 /build
 /captures

--- a/app/src/main/java/com/tradingview/lightweightcharts/example/app/view/charts/VolumeStudyFragment.kt
+++ b/app/src/main/java/com/tradingview/lightweightcharts/example/app/view/charts/VolumeStudyFragment.kt
@@ -139,16 +139,15 @@ class VolumeStudyFragment : Fragment() {
                     precision = 1,
                     minMove = 1f,
                 ),
-                priceScaleId = PriceScaleId.RIGHT,
+                priceScaleId = PriceScaleId(""),
             ),
             onSeriesCreated = { api ->
-                chartApi.priceScale(PriceScaleId.RIGHT)
-                    .applyOptions(PriceScaleOptions().apply {
-                        scaleMargins = PriceScaleMargins(
-                            top = 0.8f,
-                            bottom = 0f,
-                        )
-                    })
+                api.priceScale().applyOptions(PriceScaleOptions().apply {
+                    scaleMargins = PriceScaleMargins(
+                        top = 0.8f,
+                        bottom = 0f,
+                    )
+                })
 
 
                 api.setData(data.list)

--- a/lightweightlibrary/lib/app/chart-registration-functions-controller.js
+++ b/lightweightlibrary/lib/app/chart-registration-functions-controller.js
@@ -1,13 +1,13 @@
 import SeriesFunctionManager from "./series/series-function-manager.js";
 import SubscriptionsFunctionManager from "./subscriptions-function-manager";
-import PriceScaleFunctionManager from "./price-scale-function-manager";
 import TimeScaleFunctionManager from "./time-scale/time-scale-function-manager";
 import { logger } from './logger.js';
 import { Locator } from "./service-locator/locator.js";
+import PriceScaleFunctionManager from "./price-scale/price-scale-function-manager";
 
 export default class ChartRegistrationFunctionsController {
 
-  constructor(chart, functionManager, pluginManager) {
+    constructor(chart, functionManager, pluginManager) {
         this.chart = chart
         this.functionManager = functionManager
         this.pluginManager = pluginManager
@@ -15,21 +15,21 @@ export default class ChartRegistrationFunctionsController {
     }
 
     registerFunctions() {
-        const seriesFunctionManager = Locator.resolve(SeriesFunctionManager.name)
-        seriesFunctionManager.register()
+        const seriesFunctionManager = Locator.resolve(SeriesFunctionManager.name);
+        seriesFunctionManager.register();
 
         const subscriptions = new SubscriptionsFunctionManager(
             this.chart,
             this.functionManager,
             seriesFunctionManager
         )
-        subscriptions.register()
+        subscriptions.register();
 
-        const timeScale = Locator.resolve(TimeScaleFunctionManager.name)
-        timeScale.register()
+        const timeScale = Locator.resolve(TimeScaleFunctionManager.name);
+        timeScale.register();
+        const priceScale = Locator.resolve(PriceScaleFunctionManager.name);
+        priceScale.register();
 
-        const priceScale = new PriceScaleFunctionManager(this.chart, this.functionManager)
-        priceScale.register()
 
         this.functionManager.registerFunction("remove", (params, resolve) => {
             this.cache.clear()

--- a/lightweightlibrary/lib/app/price-scale-function-manager.js
+++ b/lightweightlibrary/lib/app/price-scale-function-manager.js
@@ -12,14 +12,6 @@ export default class PriceScaleFunctionManager {
         this.functionManager.registerFunction("priceScale", (input, resolve) => {
             this.cache.set(input.uuid, this.chart.priceScale(input.params.priceScaleId))
         })
-        this.functionManager.registerFunction("priceScaleOptions", (input, resolve) => {
-            const scale = this.cache.get(input.params.caller)
-            if (scale === undefined) {
-                this.functionManager.throwFatalError(new Error(`PriceScale with uuid:${input.caller} is not found`), input)
-            } else {
-                resolve(scale.options())
-            }
-        })
         this.functionManager.registerFunction("priceScaleApplyOptions", (input, resolve) => {
             const scale = this.cache.get(input.params.caller)
             if (scale === undefined) {

--- a/lightweightlibrary/lib/app/price-scale-function-manager.js
+++ b/lightweightlibrary/lib/app/price-scale-function-manager.js
@@ -1,5 +1,3 @@
-import { logger } from './logger.js'
-
 export default class PriceScaleFunctionManager {
 
     constructor(chart, functionManager) {

--- a/lightweightlibrary/lib/app/price-scale/price-scale-cache.js
+++ b/lightweightlibrary/lib/app/price-scale/price-scale-cache.js
@@ -1,0 +1,3 @@
+export default class PriceScaleCache extends Map {
+   
+}

--- a/lightweightlibrary/lib/app/price-scale/price-scale-creation.js
+++ b/lightweightlibrary/lib/app/price-scale/price-scale-creation.js
@@ -1,0 +1,73 @@
+import FunctionManager from "../function-manager.js";
+import ServiceLocator from "../service-locator/locator.js";
+import PriceScaleCache from "./price-scale-cache.js";
+import SeriesCache from "../series/series-cache.js";
+
+export default class PriceScaleCreationService {
+
+    /**
+     * 
+     * @param {ServiceLocator} locator 
+     */
+    constructor(locator,) {
+        this.chart = locator.resolve("chart");
+        this.pricescalesCache = locator.resolve(PriceScaleCache.name);
+        this.seriesCache = locator.resolve(SeriesCache.name);
+        this.functionManager = locator.resolve(FunctionManager.name);
+    }
+
+    register() {
+        this._createPriceApiFunctions().forEach((method) => {
+            this.functionManager.registerFunction(method.name, (input, resolve) => {
+                this._addPriceScale(input.uuid, method.invoke(input));
+                resolve(input.uuid);
+            });
+        });
+    }
+
+    _addPriceScale(uuid, series) {
+        this.pricescalesCache.set(uuid, series);
+    }
+
+    _createPriceApiFunctions() {
+        return [
+            new PriceScaleChart(this.chart),
+            new SeriesPriceScaleChart(this.seriesCache),
+        ];
+    }
+}
+
+class SeriesCreationMethod {
+    constructor(name, invoke) {
+        this.name = name;
+        this.invoke = invoke;
+    }
+}
+
+class PriceScaleChart extends SeriesCreationMethod {
+    constructor(chart) {
+        super("priceScale", function (input) {
+            return chart.priceScale(input.params.priceScaleId);
+        })
+    }
+}
+
+
+class SeriesPriceScaleChart extends SeriesCreationMethod {
+    constructor(seriesCache) {
+        super("seriesPriceScale", function (input) {
+            const series = this._findSeries(input);
+            return series.priceScale();
+        })
+        this.seriesCache = seriesCache;
+    }
+
+    _findSeries(input) {
+        let series = this.seriesCache.get(input.params.seriesId)
+        if (series === undefined) {
+            this.functionManager.throwFatalError(new Error(`${seriesName} with uuid:${input.uuid} is not found`), input);
+        }
+
+        return series;
+    }
+}

--- a/lightweightlibrary/lib/app/price-scale/price-scale-creation.js
+++ b/lightweightlibrary/lib/app/price-scale/price-scale-creation.js
@@ -1,5 +1,4 @@
 import FunctionManager from "../function-manager.js";
-import ServiceLocator from "../service-locator/locator.js";
 import PriceScaleCache from "./price-scale-cache.js";
 import SeriesCache from "../series/series-cache.js";
 
@@ -55,7 +54,7 @@ class PriceScaleChart extends SeriesCreationMethod {
 
 class SeriesPriceScaleChart extends SeriesCreationMethod {
     constructor(seriesCache) {
-        super("seriesPriceScale", function (input) {
+        super("priceScaleSeries", function (input) {
             const series = this._findSeries(input);
             return series.priceScale();
         })

--- a/lightweightlibrary/lib/app/price-scale/price-scale-function-manager.js
+++ b/lightweightlibrary/lib/app/price-scale/price-scale-function-manager.js
@@ -1,5 +1,4 @@
 import FunctionManager from '../function-manager.js';
-import ServiceLocator from '../service-locator/locator.js';
 import PriceScaleCreationService from './price-scale-creation.js';
 import PriceScaleInstanceService from './price-scale-instance.js';
 

--- a/lightweightlibrary/lib/app/price-scale/price-scale-function-manager.js
+++ b/lightweightlibrary/lib/app/price-scale/price-scale-function-manager.js
@@ -1,0 +1,23 @@
+import FunctionManager from '../function-manager.js';
+import ServiceLocator from '../service-locator/locator.js';
+import PriceScaleCreationService from './price-scale-creation.js';
+import PriceScaleInstanceService from './price-scale-instance.js';
+
+export default class PriceScaleFunctionManager {
+
+    /**
+     * 
+     * @param {ServiceLocator} locator 
+     */
+    constructor(locator) {
+        this.functionManager = locator.resolve(FunctionManager.name);
+        this.creationService = locator.resolve(PriceScaleCreationService.name);
+        this.instanceService = locator.resolve(PriceScaleInstanceService.name);
+    }
+
+    register() {
+        this.creationService.register();
+        this.instanceService.register();
+    }
+
+}

--- a/lightweightlibrary/lib/app/price-scale/price-scale-instance.js
+++ b/lightweightlibrary/lib/app/price-scale/price-scale-instance.js
@@ -10,20 +10,20 @@ export default class PriceScaleInstanceService {
     }
 
     register() {
-        this._seriesInstanceMethods().forEach((method) => {
+        this._priceScaleInstanceMethods().forEach((method) => {
             this.functionManager.registerFunction(method.name, (input, resolve) => {
                 const scale = this.priceScaleCache.get(input.params.caller)
                 if (scale === undefined) {
                     this.functionManager.throwFatalError(new Error(`PriceScale with uuid:${input.caller} is not found`), input)
                 } else {
-                    method.invoke(scale,input.params,resolve)
+                    method.invoke(scale, input.params, resolve)
                 }
             });
         });
 
     }
 
-    _seriesInstanceMethods() {
+    _priceScaleInstanceMethods() {
         return [
             new ApplyOptions(),
             new PriceScaleWidth(),
@@ -37,19 +37,11 @@ export default class PriceScaleInstanceService {
         ];
     }
 
-    _findSeries(input, callback) {
-        let series = this.seriesCache.get(input.params.seriesId)
-        if (series === undefined) {
-            this.functionManager.throwFatalError(new Error(`${seriesName} with uuid:${input.uuid} is not found`), input)
-        } else {
-            callback(series)
-        }
-    }
 }
 
 /**
  * ==============================================================
- * Methods of series instance
+ * Methods of price-scale instance
  * ==============================================================
  */
 class PriceScaleInstanceMethod {
@@ -61,7 +53,7 @@ class PriceScaleInstanceMethod {
 
 class ApplyOptions extends PriceScaleInstanceMethod {
     constructor() {
-        super("priceScaleApplyOptions", function(scale, params, resolve) {
+        super("priceScaleApplyOptions", function (scale, params, resolve) {
             scale.applyOptions(params.options)
         });
     }
@@ -70,7 +62,7 @@ class ApplyOptions extends PriceScaleInstanceMethod {
 
 class PriceScaleWidth extends PriceScaleInstanceMethod {
     constructor() {
-        super("priceScaleWidth", function(scale, params, resolve) {
+        super("priceScaleWidth", function (scale, params, resolve) {
             resolve(scale.width())
         });
     }

--- a/lightweightlibrary/lib/app/price-scale/price-scale-instance.js
+++ b/lightweightlibrary/lib/app/price-scale/price-scale-instance.js
@@ -1,0 +1,77 @@
+import FunctionManager from "../function-manager.js";
+import PriceScaleCache from "./price-scale-cache.js";
+
+export default class PriceScaleInstanceService {
+
+    constructor(locator) {
+        this.chart = locator.resolve("chart");
+        this.priceScaleCache = locator.resolve(PriceScaleCache.name);
+        this.functionManager = locator.resolve(FunctionManager.name);
+    }
+
+    register() {
+        this._seriesInstanceMethods().forEach((method) => {
+            this.functionManager.registerFunction(method.name, (input, resolve) => {
+                const scale = this.priceScaleCache.get(input.params.caller)
+                if (scale === undefined) {
+                    this.functionManager.throwFatalError(new Error(`PriceScale with uuid:${input.caller} is not found`), input)
+                } else {
+                    method.invoke(scale,input.params,resolve)
+                }
+            });
+        });
+
+    }
+
+    _seriesInstanceMethods() {
+        return [
+            new ApplyOptions(),
+            new PriceScaleWidth(),
+        ];
+    }
+
+    _priceLineMethods() {
+        return [
+            new PriceLineOptions(),
+            new PriceLineApplyOptions()
+        ];
+    }
+
+    _findSeries(input, callback) {
+        let series = this.seriesCache.get(input.params.seriesId)
+        if (series === undefined) {
+            this.functionManager.throwFatalError(new Error(`${seriesName} with uuid:${input.uuid} is not found`), input)
+        } else {
+            callback(series)
+        }
+    }
+}
+
+/**
+ * ==============================================================
+ * Methods of series instance
+ * ==============================================================
+ */
+class PriceScaleInstanceMethod {
+    constructor(name, invoke) {
+        this.name = name;
+        this.invoke = invoke;
+    }
+}
+
+class ApplyOptions extends PriceScaleInstanceMethod {
+    constructor() {
+        super("priceScaleApplyOptions", function(scale, params, resolve) {
+            scale.applyOptions(params.options)
+        });
+    }
+}
+
+
+class PriceScaleWidth extends PriceScaleInstanceMethod {
+    constructor() {
+        super("priceScaleWidth", function(scale, params, resolve) {
+            resolve(scale.width())
+        });
+    }
+}

--- a/lightweightlibrary/lib/app/series/line-service.js
+++ b/lightweightlibrary/lib/app/series/line-service.js
@@ -1,5 +1,4 @@
 import FunctionManager from "../function-manager";
-import ServiceLocator from "../service-locator/locator";
 import LineCache from "./line-cache";
 
 export default class LineService {

--- a/lightweightlibrary/lib/app/series/price-formatter.js
+++ b/lightweightlibrary/lib/app/series/price-formatter.js
@@ -1,5 +1,4 @@
 import PluginManager from "../plugin-manager";
-import ServiceLocator from "../service-locator/locator";
 
 export default class PriceFormatterService {
 

--- a/lightweightlibrary/lib/app/series/series-creation.js
+++ b/lightweightlibrary/lib/app/series/series-creation.js
@@ -1,6 +1,5 @@
 import FunctionManager from "../function-manager";
 import PluginManager from "../plugin-manager";
-import ServiceLocator from "../service-locator/locator";
 import SeriesCache from "./series-cache";
 
 export default class SeriesCreationService {

--- a/lightweightlibrary/lib/app/series/series-function-manager.js
+++ b/lightweightlibrary/lib/app/series/series-function-manager.js
@@ -1,6 +1,4 @@
 import FunctionManager from '../function-manager.js';
-import { logger } from '../logger.js'
-import ServiceLocator from '../service-locator/locator.js';
 import SeriesCache from './series-cache.js';
 import SeriesCreationService from './series-creation.js'
 import SeriesInstanceService from './series-instance.js';

--- a/lightweightlibrary/lib/app/service-locator/locator-component.js
+++ b/lightweightlibrary/lib/app/service-locator/locator-component.js
@@ -10,6 +10,10 @@ import SeriesInstanceService from "../series/series-instance";
 import TickMarkFormatterService from "../time-scale/tick-mark-formatter";
 import TimeScaleFunctionManager from "../time-scale/time-scale-function-manager";
 import TimeScaleInstanceService from "../time-scale/time-scale-instance";
+import PriceScaleCache from "../price-scale/price-scale-cache";
+import PriceScaleCreationService from "../price-scale/price-scale-creation";
+import PriceScaleInstanceService from "../price-scale/price-scale-instance";
+import PriceScaleFunctionManager from "../price-scale/price-scale-function-manager";
 import { Locator } from "./locator";
 
 export function initLocator(functionManager, pluginManager, chart) {
@@ -37,6 +41,13 @@ class LocatorComponent {
 
         this.registerTimeScaleFunctionManager();
         this.registerTimeScaleInstanceService();
+
+        this.registerPriceScaleCache();
+        this.registerPriceScaleCreationService();
+        this.registerPriceScaleInstanceService();
+        this.registerPriceScaleFunctionManager();
+
+
         this.registerTickMarkFormatterService();
     }
 
@@ -50,6 +61,10 @@ class LocatorComponent {
 
     registerSeriesCache() {
         Locator.register(SeriesCache.name, () => new SeriesCache());
+    }
+
+    registerPriceScaleCache() {
+        Locator.register(PriceScaleCache.name, () => new PriceScaleCache());
     }
 
     registerSeriesFunctionManager() {
@@ -74,6 +89,18 @@ class LocatorComponent {
 
     registerTimeScaleInstanceService() {
         Locator.register(TimeScaleInstanceService.name, () => new TimeScaleInstanceService(Locator));
+    }
+
+    registerPriceScaleCreationService(){
+        Locator.register(PriceScaleCreationService.name, () => new PriceScaleCreationService(Locator));
+    }
+
+    registerPriceScaleInstanceService(){
+        Locator.register(PriceScaleInstanceService.name, () => new PriceScaleInstanceService(Locator));
+    }
+
+    registerPriceScaleFunctionManager(){
+        Locator.register(PriceScaleFunctionManager.name, () => new PriceScaleFunctionManager(Locator));
     }
 
     registerTickMarkFormatterService() {

--- a/lightweightlibrary/lib/app/service-locator/locator.js
+++ b/lightweightlibrary/lib/app/service-locator/locator.js
@@ -33,5 +33,6 @@ class ContainerWrapper {
 }
 
 export const Locator = new ServiceLocator();
+window.locator = Locator
 
 import './locator-component';

--- a/lightweightlibrary/lib/app/time-scale/tick-mark-formatter.js
+++ b/lightweightlibrary/lib/app/time-scale/tick-mark-formatter.js
@@ -1,5 +1,4 @@
 import PluginManager from "../plugin-manager";
-import ServiceLocator from "../service-locator/locator";
 
 export default class TickMarkFormatterService {
 

--- a/lightweightlibrary/lib/app/time-scale/time-scale-function-manager.js
+++ b/lightweightlibrary/lib/app/time-scale/time-scale-function-manager.js
@@ -1,4 +1,3 @@
-import ServiceLocator from "../service-locator/locator";
 import TimeScaleInstanceService from "./time-scale-instance";
 
 export default class TimeScaleFunctionManager {

--- a/lightweightlibrary/lib/app/time-scale/time-scale-instance.js
+++ b/lightweightlibrary/lib/app/time-scale/time-scale-instance.js
@@ -1,6 +1,5 @@
 import FunctionManager from "../function-manager";
 import PluginManager from "../plugin-manager";
-import ServiceLocator from "../service-locator/locator";
 import TickMarkFormatterService from "./tick-mark-formatter";
 
 export default class TimeScaleInstanceService {

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/SeriesApiDelegate.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/SeriesApiDelegate.kt
@@ -5,7 +5,7 @@ import com.tradingview.lightweightcharts.api.interfaces.SeriesApi
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.APPLY_OPTIONS
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.COORDINATE_TO_PRICE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.CREATE_PRICE_LINE
-import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.PRICE_SCALE
+import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.PRICE_SCALE_SERIES
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.PRICE_TO_COORDINATE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.REMOVE_PRICE_LINE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.SERIES_TYPE
@@ -97,7 +97,7 @@ class SeriesApiDelegate<T: SeriesOptionsCommon>(
 
     override fun priceScale(): PriceScaleApi {
         val uuid = controller.callFunction(
-            PRICE_SCALE,
+            PRICE_SCALE_SERIES,
             mapOf(
                 SERIES_UUID to uuid,
             )

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/SeriesApiDelegate.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/SeriesApiDelegate.kt
@@ -1,9 +1,11 @@
 package com.tradingview.lightweightcharts.api.delegates
 
+import com.tradingview.lightweightcharts.api.interfaces.PriceScaleApi
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.APPLY_OPTIONS
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.COORDINATE_TO_PRICE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.CREATE_PRICE_LINE
+import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.PRICE_SCALE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.PRICE_TO_COORDINATE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.REMOVE_PRICE_LINE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.SERIES_TYPE
@@ -19,10 +21,12 @@ import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.PRICE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.SERIES_UUID
 import com.tradingview.lightweightcharts.api.options.models.PriceLineOptions
 import com.tradingview.lightweightcharts.api.options.models.SeriesOptionsCommon
-import com.tradingview.lightweightcharts.api.serializer.PrimitiveSerializer
 import com.tradingview.lightweightcharts.api.serializer.Deserializer
+import com.tradingview.lightweightcharts.api.serializer.PrimitiveSerializer
 import com.tradingview.lightweightcharts.api.serializer.SeriesTypeDeserializer
-import com.tradingview.lightweightcharts.api.series.common.*
+import com.tradingview.lightweightcharts.api.series.common.PriceLine
+import com.tradingview.lightweightcharts.api.series.common.PriceLineDelegate
+import com.tradingview.lightweightcharts.api.series.common.SeriesData
 import com.tradingview.lightweightcharts.api.series.enums.SeriesType
 import com.tradingview.lightweightcharts.api.series.models.SeriesMarker
 import com.tradingview.lightweightcharts.runtime.controller.WebMessageController
@@ -89,6 +93,16 @@ class SeriesApiDelegate<T: SeriesOptionsCommon>(
             callback = onOptionsReceived,
             deserializer = optionsDeserializer
         )
+    }
+
+    override fun priceScale(): PriceScaleApi {
+        val uuid = controller.callFunction(
+            PRICE_SCALE,
+            mapOf(
+                SERIES_UUID to uuid,
+            )
+        )
+        return PriceScaleApiDelegate(uuid, controller)
     }
 
     override fun setMarkers(data: List<SeriesMarker>) {

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/SeriesApi.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/SeriesApi.kt
@@ -1,9 +1,9 @@
 package com.tradingview.lightweightcharts.api.interfaces
 
-import com.tradingview.lightweightcharts.api.series.common.SeriesData
-import com.tradingview.lightweightcharts.api.series.common.PriceLine
-import com.tradingview.lightweightcharts.api.options.models.SeriesOptionsCommon
 import com.tradingview.lightweightcharts.api.options.models.PriceLineOptions
+import com.tradingview.lightweightcharts.api.options.models.SeriesOptionsCommon
+import com.tradingview.lightweightcharts.api.series.common.PriceLine
+import com.tradingview.lightweightcharts.api.series.common.SeriesData
 import com.tradingview.lightweightcharts.api.series.enums.SeriesType
 import com.tradingview.lightweightcharts.api.series.models.SeriesMarker
 
@@ -20,6 +20,7 @@ interface SeriesApi {
         const val PRICE_TO_COORDINATE = "priceToCoordinate"
         const val COORDINATE_TO_PRICE = "coordinateToPrice"
         const val APPLY_OPTIONS = "applyOptions"
+        const val PRICE_SCALE = "seriesPriceScale"
         const val SET_MARKERS = "setMarkers"
         const val CREATE_PRICE_LINE = "createPriceLine"
         const val REMOVE_PRICE_LINE = "removePriceLine"
@@ -64,6 +65,11 @@ interface SeriesApi {
      * @param onOptionsReceived full set of currently applied options, including defaults
      */
     fun options(onOptionsReceived: (SeriesOptionsCommon) -> Unit)
+
+    /**
+     * Returns interface of the price scale the series is currently attached
+     */
+    fun priceScale(): PriceScaleApi
 
     /**
      * Sets or replaces series data

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/SeriesApi.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/SeriesApi.kt
@@ -20,7 +20,7 @@ interface SeriesApi {
         const val PRICE_TO_COORDINATE = "priceToCoordinate"
         const val COORDINATE_TO_PRICE = "coordinateToPrice"
         const val APPLY_OPTIONS = "applyOptions"
-        const val PRICE_SCALE = "seriesPriceScale"
+        const val PRICE_SCALE_SERIES = "priceScaleSeries"
         const val SET_MARKERS = "setMarkers"
         const val CREATE_PRICE_LINE = "createPriceLine"
         const val REMOVE_PRICE_LINE = "removePriceLine"


### PR DESCRIPTION
# Feature  

serial options moved to pricescale options. So we need support to use pricescale from serials directly. 

# Refs 
 - [scaleMargins option has been removed from series options](https://tradingview.github.io/lightweight-charts/docs/migrations/from-v3-to-v4#scalemargins-option-has-been-removed-from-series-options)